### PR TITLE
Feature/html5 head align

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Result:
 <table>
 <thead>
 <tr>
-<th align="left">th</th>
-<th align="center">th(center)</th>
-<th align="right">th(right<)/th>
+<th style="text-align: left">th</th>
+<th style="text-align: center">th(center)</th>
+<th style="text-align: right">th(right<)/th>
 </tr>
 </thead>
 <tbody>

--- a/src/TableCellRenderer.php
+++ b/src/TableCellRenderer.php
@@ -31,7 +31,6 @@ class TableCellRenderer implements BlockRendererInterface
         }
 
         if ($block->align) {
-            error_log($block->type . "done\n", 3, "/home/tewi/error.log");
             if ($block->type == TableCell::TYPE_HEAD) {
                 $attrs['style'] = "text-align: $block->align";
             } else {

--- a/src/TableCellRenderer.php
+++ b/src/TableCellRenderer.php
@@ -31,7 +31,12 @@ class TableCellRenderer implements BlockRendererInterface
         }
 
         if ($block->align) {
-            $attrs['align'] = $block->align;
+            error_log($block->type . "done\n", 3, "/home/tewi/error.log");
+            if ($block->type == TableCell::TYPE_HEAD) {
+                $attrs['style'] = "text-align: $block->align";
+            } else {
+                $attrs['align'] = $block->align;
+            }
         }
 
         return new HtmlElement($block->type, $attrs, $htmlRenderer->renderInlines($block->children()));

--- a/tests/Functional/data/aligned_table.html
+++ b/tests/Functional/data/aligned_table.html
@@ -1,9 +1,9 @@
 <table>
 <thead>
 <tr>
-<th align="left">header 1</th>
-<th align="center">header 2</th>
-<th align="right">header 2</th>
+<th style="text-align: left">header 1</th>
+<th style="text-align: center">header 2</th>
+<th style="text-align: right">header 2</th>
 </tr>
 </thead>
 <tbody>

--- a/tests/Functional/data/simple_table.html
+++ b/tests/Functional/data/simple_table.html
@@ -20,7 +20,7 @@
 <table>
 <thead>
 <tr>
-<th align="left">header 1</th>
+<th style="text-align: left">header 1</th>
 <th>header 2</th>
 </tr>
 </thead>

--- a/tests/Functional/data/table-aligned.html
+++ b/tests/Functional/data/table-aligned.html
@@ -2,8 +2,8 @@
 <thead>
 <tr>
 <th>th</th>
-<th align="center">th(center)</th>
-<th align="right">th(right)</th>
+<th style="text-align: center">th(center)</th>
+<th style="text-align: right">th(right)</th>
 </tr>
 </thead>
 <tbody>

--- a/tests/Functional/data/table-caption.html
+++ b/tests/Functional/data/table-caption.html
@@ -21,9 +21,9 @@
 <caption id="reference_table"><em>Prototype</em> table</caption>
 <thead>
 <tr>
-<th align="left">First Header</th>
-<th align="center">Second Header</th>
-<th align="right">Third Header</th>
+<th style="text-align: left">First Header</th>
+<th style="text-align: center">Second Header</th>
+<th style="text-align: right">Third Header</th>
 </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
th align attribute was removed in html 5. Replaced with <th style="text-align: left|center|right">