### PR TITLE
Update escape to use the new helper method

### DIFF
--- a/src/TableCaptionRenderer.php
+++ b/src/TableCaptionRenderer.php
@@ -16,6 +16,7 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Util\Xml;
 
 class TableCaptionRenderer implements BlockRendererInterface
 {
@@ -27,7 +28,7 @@ class TableCaptionRenderer implements BlockRendererInterface
 
         $attrs = [];
         foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = $htmlRenderer->escape($value, true);
+            $attrs[$key] = Xml::escape($value, true);
         }
 
         if ($block->id) {

--- a/src/TableCellRenderer.php
+++ b/src/TableCellRenderer.php
@@ -16,6 +16,7 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Util\Xml;
 
 class TableCellRenderer implements BlockRendererInterface
 {
@@ -27,7 +28,7 @@ class TableCellRenderer implements BlockRendererInterface
 
         $attrs = [];
         foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = $htmlRenderer->escape($value, true);
+            $attrs[$key] = Xml::escape($value, true);
         }
 
         if ($block->align) {

--- a/src/TableRenderer.php
+++ b/src/TableRenderer.php
@@ -16,6 +16,7 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Util\Xml;
 
 class TableRenderer implements BlockRendererInterface
 {
@@ -27,7 +28,7 @@ class TableRenderer implements BlockRendererInterface
 
         $attrs = [];
         foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = $htmlRenderer->escape($value, true);
+            $attrs[$key] = Xml::escape($value, true);
         }
 
         $separator = $htmlRenderer->getOption('inner_separator', "\n");

--- a/src/TableRowRenderer.php
+++ b/src/TableRowRenderer.php
@@ -16,6 +16,7 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Util\Xml;
 
 class TableRowRenderer implements BlockRendererInterface
 {
@@ -27,7 +28,7 @@ class TableRowRenderer implements BlockRendererInterface
 
         $attrs = [];
         foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = $htmlRenderer->escape($value, true);
+            $attrs[$key] = Xml::escape($value, true);
         }
 
         $separator = $htmlRenderer->getOption('inner_separator', "\n");

--- a/src/TableRowsRenderer.php
+++ b/src/TableRowsRenderer.php
@@ -16,6 +16,7 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
+use League\CommonMark\Util\Xml;
 
 class TableRowsRenderer implements BlockRendererInterface
 {
@@ -31,7 +32,7 @@ class TableRowsRenderer implements BlockRendererInterface
 
         $attrs = [];
         foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = $htmlRenderer->escape($value, true);
+            $attrs[$key] = Xml::escape($value, true);
         }
 
         $separator = $htmlRenderer->getOption('inner_separator', "\n");


### PR DESCRIPTION
As mentioned in the [upgrade documentation](/thephpleague/commonmark/blob/master/UPGRADE.md#htmlrendererescape), `escape` function has been moved to a utility class in 0.16.0 and the one in `HtmlElement` has been removed in 0.17.0.

I tried writing test for it but given up halfway writing the processor :)