### PR TITLE
Use the new "commonmark-extension" package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "webuni/commonmark-table-extension",
-    "type": "library",
+    "type": "commonmark-extension",
     "description": "The table extension for CommonMark PHP implementation",
     "keywords": ["markdown","table","commonmark"],
     "homepage": "https://github.com/webuni/commonmark-table-extension",


### PR DESCRIPTION
This makes it easier for people to find extensions on Packagist: https://packagist.org/packages/league/commonmark-ext-autolink?type=commonmark-extension