### PR TITLE
Remove unnecessary escaping of attributes

### DIFF
--- a/src/TableCaptionRenderer.php
+++ b/src/TableCaptionRenderer.php
@@ -19,7 +19,6 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
-use League\CommonMark\Util\Xml;
 
 final class TableCaptionRenderer implements BlockRendererInterface
 {
@@ -29,10 +28,7 @@ final class TableCaptionRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: '.get_class($block));
         }
 
-        $attrs = [];
-        foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = Xml::escape($value);
-        }
+        $attrs = $block->getData('attributes', []);
 
         if ($block->id) {
             $attrs['id'] = $block->id;

--- a/src/TableCellRenderer.php
+++ b/src/TableCellRenderer.php
@@ -19,7 +19,6 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
-use League\CommonMark\Util\Xml;
 
 final class TableCellRenderer implements BlockRendererInterface
 {
@@ -29,10 +28,7 @@ final class TableCellRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: '.get_class($block));
         }
 
-        $attrs = [];
-        foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = Xml::escape($value);
-        }
+        $attrs = $block->getData('attributes', []);
 
         if ($block->align) {
             $attrs['style'] = (isset($attrs['style']) ? $attrs['style'].' ' : '').'text-align: '.$block->align;

--- a/src/TableRenderer.php
+++ b/src/TableRenderer.php
@@ -19,7 +19,6 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
-use League\CommonMark\Util\Xml;
 
 final class TableRenderer implements BlockRendererInterface
 {
@@ -29,10 +28,7 @@ final class TableRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: '.get_class($block));
         }
 
-        $attrs = [];
-        foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = Xml::escape($value);
-        }
+        $attrs = $block->getData('attributes', []);
 
         $separator = $htmlRenderer->getOption('inner_separator', "\n");
 

--- a/src/TableRowRenderer.php
+++ b/src/TableRowRenderer.php
@@ -19,7 +19,6 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
-use League\CommonMark\Util\Xml;
 
 final class TableRowRenderer implements BlockRendererInterface
 {
@@ -29,10 +28,7 @@ final class TableRowRenderer implements BlockRendererInterface
             throw new \InvalidArgumentException('Incompatible block type: '.get_class($block));
         }
 
-        $attrs = [];
-        foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = Xml::escape($value);
-        }
+        $attrs = $block->getData('attributes', []);
 
         $separator = $htmlRenderer->getOption('inner_separator', "\n");
 

--- a/src/TableSectionRenderer.php
+++ b/src/TableSectionRenderer.php
@@ -19,7 +19,6 @@ use League\CommonMark\Block\Element\AbstractBlock;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
 use League\CommonMark\HtmlElement;
-use League\CommonMark\Util\Xml;
 
 final class TableSectionRenderer implements BlockRendererInterface
 {
@@ -33,10 +32,7 @@ final class TableSectionRenderer implements BlockRendererInterface
             return '';
         }
 
-        $attrs = [];
-        foreach ($block->getData('attributes', []) as $key => $value) {
-            $attrs[$key] = Xml::escape($value);
-        }
+        $attrs = $block->getData('attributes', []);
 
         $separator = $htmlRenderer->getOption('inner_separator', "\n");
 


### PR DESCRIPTION
As per [upgrade guide for commonmark 0.19](https://commonmark.thephpleague.com/0.19/upgrading/), attributes passed to `HtmlElement` shouldn't be escaped otherwise they'll be incorrectly double-escaped.